### PR TITLE
added AND_IMMEDIATE op

### DIFF
--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -121,6 +121,9 @@ class CPU
     // INC - INCrement memory
     const static Byte INSTR_6502_INC_ABSOLUTE_X = 0xFE;      // 7, Adds one to the value in memory, setting Z and N if required
 
+    // AND - logical AND operation
+    const static Byte INSTR_6502_AND_IMMEDIATE = 0x29;      // 2, performs (accumulator AND operand) then stores in accumulator
+
     /***************************************************************************************************************************/
 
     private:

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -540,6 +540,23 @@ void CPU::run(Memory& memory)
                     sem.wait();
                 }
                 break;
+            
+            case INSTR_6502_AND_IMMEDIATE:
+                {
+                    Byte operand = get_byte(memory);
+                    A = A & operand;
+                    if (A == 0)
+                    {
+                        Z = true;
+                    }
+                    if (A & 0b10000000)
+                    {
+                        N = true;
+                    }
+                    sem.wait();
+                    IP++;
+                }
+                break;
 
             default:
                 std::cout << "Unknown instruction: 0x" << std::hex << std::setw(2) << std::setfill('0') << (int)instruction << "\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 int main()
 {
     System NES;
-    NES.load_example_prog(8);
+    NES.load_example_prog(9);
     NES.run();
 
     return 0;

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -131,7 +131,7 @@ void System::load_example_prog(unsigned int which)
             };
         case 9:     //test for AND operations
             memory.data = {
-                0x29, 0xff // AND #$00
+                0x29, 0xff // AND #$FF
             };
     }
 }

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -22,7 +22,7 @@ inline void System::clock_function(Semaphore* cpu_sem, unsigned int cycles)
 
 void System::load_example_prog(unsigned int which)
 {
-    switch (which % 9)
+    switch (which % 10)
     {
         case 0:
             /*  Loads values into A and stores them elsewhere in memory. */
@@ -128,6 +128,10 @@ void System::load_example_prog(unsigned int which)
             memory.data = {
                 0x6c, 0x03, 0x00,       // JMP $0003
                 0xfc, 0xba
+            };
+        case 9:     //test for AND operations
+            memory.data = {
+                0x29, 0xff // AND #$00
             };
     }
 }


### PR DESCRIPTION
I plan to come back in a bit and test this.

Just wanted to show you and make sure I understood: When an operation does something internal and then moves on (i.e. doesn't explicitly mess with the IP), should that operation then IP++ ready for the CPU to read the next instruction? It seems that way from the other examples, I just wanted to check. 

Edit: I've answered the question now :P