### PR TITLE
WIP: Adding test suite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,3 +9,6 @@ include_directories(include)
 
 add_executable(${PROJECT_NAME} src/main.cpp src/cpu.cpp src/memory.cpp src/system.cpp)
 target_link_libraries(${PROJECT_NAME} -pthread -O3)
+
+add_executable(${PROJECT_NAME}_tests src/tests.cpp src/cpu.cpp src/memory.cpp src/system.cpp)
+target_link_libraries(${PROJECT_NAME}_tests -pthread -O3)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,4 +11,4 @@ add_executable(${PROJECT_NAME} src/main.cpp src/cpu.cpp src/memory.cpp src/syste
 target_link_libraries(${PROJECT_NAME} -pthread -O3)
 
 add_executable(${PROJECT_NAME}_tests src/tests.cpp src/cpu.cpp src/memory.cpp src/system.cpp)
-target_link_libraries(${PROJECT_NAME}_tests -pthread -O3)
+target_link_libraries(${PROJECT_NAME}_tests -pthread -g)

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -8,6 +8,7 @@ class Memory;
 
 class CPU
 {
+    public:
     /********** 6502 opcodes in format: Instruction name = instruction byte // num cycles, description. ************************/
 
     // LDA - LoaD Accumulator

--- a/include/system.hpp
+++ b/include/system.hpp
@@ -19,6 +19,7 @@ class System
         System();
 
         // General --------------------------------------------------------------------------------------------------------------
+        void load_short_program(std::array<Byte, 128> program);
         void load_example_prog(unsigned int which);
         static inline void clock_function(Semaphore* cpu_sem, unsigned int cycles);
         void run();

--- a/include/system.hpp
+++ b/include/system.hpp
@@ -21,7 +21,7 @@ class System
         // General --------------------------------------------------------------------------------------------------------------
         void load_short_program(std::array<Byte, 128> program);
         void load_example_prog(unsigned int which);
-        static inline void clock_function(Semaphore* cpu_sem, unsigned int cycles);
+        static inline void clock_function(Semaphore* cpu_sem, unsigned int cycles, bool* run_flag);
         void run();
 };
 

--- a/include/tests.hpp
+++ b/include/tests.hpp
@@ -1,0 +1,21 @@
+#ifndef EMU_TESTS_H
+#define EMU_TESTS_H
+
+#include <array>
+
+#include "system.hpp"
+
+class EmulatorTest
+{
+    private:
+        System nes;
+        std::array<Byte, 128> expected_result;
+    
+    public:
+        std::string name;
+        EmulatorTest(const std::array<Byte, 128>& program, const std::array<Byte, 128>& expected_result, std::string name);
+        EmulatorTest(const EmulatorTest& e);
+        bool run();
+};
+
+#endif

--- a/include/tests.hpp
+++ b/include/tests.hpp
@@ -5,7 +5,7 @@
 
 #include "system.hpp"
 
-class EmulatorTest
+class MemoryTest
 {
     private:
         System nes;
@@ -13,8 +13,8 @@ class EmulatorTest
     
     public:
         std::string name;
-        EmulatorTest(const std::array<Byte, 128>& program, const std::array<Byte, 128>& expected_result, std::string name);
-        EmulatorTest(const EmulatorTest& e);
+        MemoryTest(const std::array<Byte, 128>& program, const std::array<Byte, 128>& expected_result, std::string name);
+        MemoryTest(const MemoryTest& e);
         bool run();
 };
 

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -5,7 +5,7 @@
 #include "memory.hpp"
 #include "semaphore.hpp"
 
-#define DEBUG 1
+#define DEBUG 0
 
 CPU::CPU()
 {
@@ -470,7 +470,6 @@ void CPU::run(Memory& memory)
                 set_byte(memory, SP, IP);
                 SP--;
                 set_byte(memory, SP, flags_as_byte());
-                std::cout << "BRK reached" << std::endl;
                 return;
 
             case INSTR_6502_JSR_ABSOLUTE:

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -1,11 +1,19 @@
 #include <thread>
 
+#include <string.h>
+
 #include "system.hpp"
 
 System::System()
 {
     memory.data = {0};
 }
+
+void System::load_short_program(std::array<Byte, 128> program)
+{
+    memcpy(memory.data.data(), program.data(), 128);
+}
+
 
 inline void System::clock_function(Semaphore* cpu_sem, unsigned int cycles)
 {

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -15,12 +15,12 @@ void System::load_short_program(std::array<Byte, 128> program)
 }
 
 
-inline void System::clock_function(Semaphore* cpu_sem, unsigned int cycles)
+void System::clock_function(Semaphore* cpu_sem, unsigned int cycles, bool* run_flag)
 {
     auto time = std::chrono::system_clock::now();
     std::chrono::milliseconds interval{100};
 
-    while (cycles--)
+    while (cycles-- && *run_flag)
     {
         time += interval;
         std::this_thread::sleep_until(time);
@@ -146,7 +146,9 @@ void System::load_example_prog(unsigned int which)
 
 void System::run()
 {
-    std::thread clock_thread{clock_function, &cpu.sem, 1000};
+    bool GO = true;
+    std::thread clock_thread{clock_function, &cpu.sem, 1000, &GO};
     cpu.run(memory);
+    GO = false;
     clock_thread.join();
 }

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -1,0 +1,67 @@
+#include <vector>
+#include <iostream>
+
+#include "tests.hpp"
+
+EmulatorTest::EmulatorTest(const std::array<Byte, 128>& program, const std::array<Byte, 128>& expected_result, std::string name)
+{
+    this->nes.load_short_program(program);
+    this->name = name;
+    this->expected_result = expected_result;
+}
+
+/** \brief Copy constructor. */
+EmulatorTest::EmulatorTest(const EmulatorTest& other)
+{
+    this->nes.memory.data = other.nes.memory.data;
+    this->name = other.name;
+    this->expected_result = other.expected_result;
+}
+
+bool EmulatorTest::run()
+{
+    if (name == "Test3")
+        return false;
+    else
+        return true;
+}
+
+std::string red_text(std::string str)
+{
+    return "\033[1;31m" + str + "\033[0m";
+}
+
+std::string green_text(std::string str)
+{
+    return "\033[1;32m" + str + "\033[0m";
+}
+
+int main()
+{
+    std::cout << "COMPILING TESTS" << std::endl;
+    std::cout << "====================================" << std::endl;
+    std::vector<EmulatorTest> tests;
+    tests.emplace_back(EmulatorTest{std::array<Byte, 128>{1, 2, 3, 4}, std::array<Byte, 128>{1, 2, 3, 4}, "Test1"});
+    tests.emplace_back(EmulatorTest{std::array<Byte, 128>{1, 2, 3, 4}, std::array<Byte, 128>{1, 2, 3, 4}, "Test2"});
+    tests.emplace_back(EmulatorTest{std::array<Byte, 128>{1, 2, 3, 4}, std::array<Byte, 128>{1, 2, 3, 4}, "Test3"});
+    tests.emplace_back(EmulatorTest{std::array<Byte, 128>{1, 2, 3, 4}, std::array<Byte, 128>{1, 2, 3, 4}, "Test4"});
+
+    int tests_passed = 0;
+
+    for (auto& test : tests)
+    {
+        bool success = test.run();
+        if (!success)
+        {
+            std::cout << red_text("Test failed: ") << test.name << std::endl;
+        }
+        else
+        {
+            tests_passed++;
+            std::cout << green_text("Test passed: ") << test.name << std::endl;
+        }
+    }
+
+    std::cout << "====================================" << std::endl;
+    std::cout << "TESTS COMPLETED // PASSED " << tests_passed << "/" << tests.size() << std::endl;
+}

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -1,9 +1,10 @@
+#include <string.h>
 #include <vector>
 #include <iostream>
 
 #include "tests.hpp"
 
-EmulatorTest::EmulatorTest(const std::array<Byte, 128>& program, const std::array<Byte, 128>& expected_result, std::string name)
+MemoryTest::MemoryTest(const std::array<Byte, 128>& program, const std::array<Byte, 128>& expected_result, std::string name)
 {
     this->nes.load_short_program(program);
     this->name = name;
@@ -11,19 +12,17 @@ EmulatorTest::EmulatorTest(const std::array<Byte, 128>& program, const std::arra
 }
 
 /** \brief Copy constructor. */
-EmulatorTest::EmulatorTest(const EmulatorTest& other)
+MemoryTest::MemoryTest(const MemoryTest& other)
 {
     this->nes.memory.data = other.nes.memory.data;
     this->name = other.name;
     this->expected_result = other.expected_result;
 }
 
-bool EmulatorTest::run()
+bool MemoryTest::run()
 {
-    if (name == "Test3")
-        return false;
-    else
-        return true;
+    this->nes.run();
+    return !memcmp(&(this->nes.memory.data.data()[0x0300]), this->expected_result.data(), 128);
 }
 
 std::string red_text(std::string str)
@@ -38,13 +37,13 @@ std::string green_text(std::string str)
 
 int main()
 {
-    std::cout << "COMPILING TESTS" << std::endl;
-    std::cout << "====================================" << std::endl;
-    std::vector<EmulatorTest> tests;
-    tests.emplace_back(EmulatorTest{std::array<Byte, 128>{1, 2, 3, 4}, std::array<Byte, 128>{1, 2, 3, 4}, "Test1"});
-    tests.emplace_back(EmulatorTest{std::array<Byte, 128>{1, 2, 3, 4}, std::array<Byte, 128>{1, 2, 3, 4}, "Test2"});
-    tests.emplace_back(EmulatorTest{std::array<Byte, 128>{1, 2, 3, 4}, std::array<Byte, 128>{1, 2, 3, 4}, "Test3"});
-    tests.emplace_back(EmulatorTest{std::array<Byte, 128>{1, 2, 3, 4}, std::array<Byte, 128>{1, 2, 3, 4}, "Test4"});
+    std::cout << "COMPILING MEMORY TESTS" << std::endl;
+    std::cout << "================================================" << std::endl;
+    std::vector<MemoryTest> tests;
+    tests.emplace_back(MemoryTest{std::array<Byte, 128>{CPU::INSTR_6502_INC_ABSOLUTE, 0x00, 0x03}, std::array<Byte, 128>{0x01, 0x00, 0x00, 0x00}, "INC, absolute addressing, once"});
+    tests.emplace_back(MemoryTest{std::array<Byte, 128>{CPU::INSTR_6502_INC_ABSOLUTE, 0x00, 0x03}, std::array<Byte, 128>{0x01, 0x00, 0x00, 0x00}, "INC, absolute addressing, twice"});
+    tests.emplace_back(MemoryTest{std::array<Byte, 128>{CPU::INSTR_6502_INC_ABSOLUTE, 0x00, 0x03}, std::array<Byte, 128>{0x01, 0x01, 0x00, 0x00}, "Deliberately failing test"});
+    tests.emplace_back(MemoryTest{std::array<Byte, 128>{CPU::INSTR_6502_INC_ABSOLUTE, 0x00, 0x03}, std::array<Byte, 128>{0x01, 0x00, 0x00, 0x00}, "Some other test"});
 
     int tests_passed = 0;
 
@@ -62,6 +61,6 @@ int main()
         }
     }
 
-    std::cout << "====================================" << std::endl;
-    std::cout << "TESTS COMPLETED // PASSED " << tests_passed << "/" << tests.size() << std::endl;
+    std::cout << "================================================" << std::endl;
+    std::cout << "MEMORY TESTS COMPLETED  //  PASSED " << tests_passed << "/" << tests.size() << std::endl;
 }


### PR DESCRIPTION
Laying out a basic test suite. This iteration will compare the content of memory only, and will not look at CPU registers or anything else.

The intent is that the tester will implement a short program (128 bytes or less) and provide it along with the expected memory output. All program output should be stored in a 128-byte block starting at 0x0300. The test will compare this memory location against the provided expected output. The test passes if the two memories are equal.