### PR TITLE
added op AND zeropage X

### DIFF
--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -128,7 +128,7 @@ class CPU
 
     // AND - logical AND operation
     const static Byte INSTR_6502_AND_IMMEDIATE = 0x29;      // 2, performs (accumulator AND operand) then stores in accumulator
-
+    const static Byte INSTR_6502_AND_ZEROPAGE_X = 0x35;     // 4, performs (accumulator AND operand) then stores in accumulator
     /***************************************************************************************************************************/
 
     private:

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -612,6 +612,27 @@ void CPU::run(Memory& memory)
                 }
                 break;
 
+            case INSTR_6502_AND_ZEROPAGE_X:
+                {
+                    //get address, add X, wrap if necessary
+                    Byte lookup_address = (get_byte(memory) + X) & 0xff;
+                    Byte operand = get_byte(memory, lookup_address);
+                    IP++;
+                    A = A & operand;
+                    if (A == 0)
+                    {
+                        Z = true;
+                    }
+                    if (A & 0b10000000)
+                    {
+                        N = true;
+                    }
+                    sem.wait();
+                    sem.wait();
+                    sem.wait();
+                }
+                break;
+
             default:
                 std::cout << "Unknown instruction: 0x" << std::hex << std::setw(2) << std::setfill('0') << (int)instruction << "\n";
                 return;


### PR DESCRIPTION
Added and tested the AND op with zero page X address mode.

I haven't tested this one yet but it should be fine due to its similarity to the other one. I'll test after merge to avoid an obvious conflict.

I thought doing two together in separate branched would be a good way to make sure git has no problems there.

Also, I looked at your LDA with zeropage X to get an idea of how you laid yours out. Have you done anything with that one to avoid address overflow out of page zero? The ref says to wrap-around the address so that it always stays within 2 bytes. I've used and AND with 0xFF to do that in mine.