### PR TITLE
Mark and absolute x

### DIFF
--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -131,6 +131,7 @@ class CPU
     const static Byte INSTR_6502_AND_ZEROPAGE_X = 0x35;     // 4, performs (accumulator AND operand) then stores in accumulator
     const static Byte INSTR_6502_AND_ZEROPAGE = 0x25;       // 3, performs (accumulator AND operand) then stores in accumulator
     const static Byte INSTR_6502_AND_ABSOLUTE = 0x2d;       // 4, performs (accumulator AND operand) then stores in accumulator
+    const static Byte INSTR_6502_AND_ABSOLUTE_X = 0x3d;       // 4 (+1 if page boundary crossed), performs (accumulator AND operand) then stores in accumulator
 
     /***************************************************************************************************************************/
 

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -130,6 +130,7 @@ class CPU
     const static Byte INSTR_6502_AND_IMMEDIATE = 0x29;      // 2, performs (accumulator AND operand) then stores in accumulator
     const static Byte INSTR_6502_AND_ZEROPAGE_X = 0x35;     // 4, performs (accumulator AND operand) then stores in accumulator
     const static Byte INSTR_6502_AND_ZEROPAGE = 0x25;       // 3, performs (accumulator AND operand) then stores in accumulator
+    const static Byte INSTR_6502_AND_ABSOLUTE = 0x2d;       // 4, performs (accumulator AND operand) then stores in accumulator
 
     /***************************************************************************************************************************/
 

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -657,6 +657,7 @@ void CPU::run(Memory& memory)
                     Word lookup_address = get_word(memory);
                     Byte operand = get_byte(memory, lookup_address);
                     IP++;
+                    IP++;
                     A = A & operand;
                     if (A == 0)
                     {

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -652,6 +652,26 @@ void CPU::run(Memory& memory)
                 }
                 break;
 
+            case INSTR_6502_AND_ABSOLUTE:
+                {
+                    Word lookup_address = get_word(memory);
+                    Byte operand = get_byte(memory, lookup_address);
+                    IP++;
+                    A = A & operand;
+                    if (A == 0)
+                    {
+                        Z = true;
+                    }
+                    if (A & 0b10000000)
+                    {
+                        N = true;
+                    }
+                    sem.wait();
+                    sem.wait();
+                    sem.wait();
+                }
+                break;
+
             default:
                 std::cout << "Unknown instruction: 0x" << std::hex << std::setw(2) << std::setfill('0') << (int)instruction << "\n";
                 return;

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -681,6 +681,7 @@ void CPU::run(Memory& memory)
                     Word new_page = lookup_address & 0xFF00;
                     Byte operand = get_byte(memory, lookup_address);
                     IP++;
+                    IP++;
                     A = A & operand;
                     if (A == 0)
                     {

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -655,6 +655,9 @@ void CPU::run(Memory& memory)
             case INSTR_6502_AND_ABSOLUTE:
                 {
                     Word lookup_address = get_word(memory);
+                    Word old_page = lookup_address & 0xFF00;
+                    lookup_address += X;
+                    Word new_page = lookup_address & 0xFF00;
                     Byte operand = get_byte(memory, lookup_address);
                     IP++;
                     A = A & operand;
@@ -669,6 +672,10 @@ void CPU::run(Memory& memory)
                     sem.wait();
                     sem.wait();
                     sem.wait();
+                    if (old_page != new_page) 
+                    {
+                        sem.wait();
+                    }
                 }
                 break;
 

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -655,6 +655,26 @@ void CPU::run(Memory& memory)
             case INSTR_6502_AND_ABSOLUTE:
                 {
                     Word lookup_address = get_word(memory);
+                    Byte operand = get_byte(memory, lookup_address);
+                    IP++;
+                    A = A & operand;
+                    if (A == 0)
+                    {
+                        Z = true;
+                    }
+                    if (A & 0b10000000)
+                    {
+                        N = true;
+                    }
+                    sem.wait();
+                    sem.wait();
+                    sem.wait();
+                }
+                break;
+            
+            case INSTR_6502_AND_ABSOLUTE_X:
+                {
+                    Word lookup_address = get_word(memory);
                     Word old_page = lookup_address & 0xFF00;
                     lookup_address += X;
                     Word new_page = lookup_address & 0xFF00;

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -131,8 +131,7 @@ void System::load_example_prog(unsigned int which)
             };
         case 9:     //test for AND operations
             memory.data = {
-                0x2d, 0x04, 0x00, //AND $0004
-                0x00, 0xc0
+                0x3d, 0x00 //AND $0000, X
             };
     }
 }

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -131,8 +131,8 @@ void System::load_example_prog(unsigned int which)
             };
         case 9:     //test for AND operations
             memory.data = {
-                0x25, 0x03, //AND $03
-                0x00, 0xc0 //BRK
+                0x2d, 0x04, 0x00, //AND $0004
+                0x00, 0xc0
             };
     }
 }


### PR DESCRIPTION
Added and tested the AND op with absolute, x address mode.

I looked up how other people do multiple branches and this time I've made this branch from the previous branch. Hopefully this means that git will know the changes are in series, not parallel.

Also, just in case I didn't figure it out again: With your STA_ABSOLUTE_Y, are you doing anything to check for the extra cycle needed if the page boundary is crossed?

I've used (address & 0xFF00) to get the 'page number' before and after adding X, then if there's a change I add an extra sem.wait()