### PR TITLE
Mark and absolute y

### DIFF
--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -132,6 +132,7 @@ class CPU
     const static Byte INSTR_6502_AND_ZEROPAGE = 0x25;       // 3, performs (accumulator AND operand) then stores in accumulator
     const static Byte INSTR_6502_AND_ABSOLUTE = 0x2d;       // 4, performs (accumulator AND operand) then stores in accumulator
     const static Byte INSTR_6502_AND_ABSOLUTE_X = 0x3d;       // 4 (+1 if page boundary crossed), performs (accumulator AND operand) then stores in accumulator
+    const static Byte INSTR_6502_AND_INDIRECT_X = 0x21;       // 6 performs (accumulator AND operand) then stores in accumulator
 
     /***************************************************************************************************************************/
 

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -132,6 +132,7 @@ class CPU
     const static Byte INSTR_6502_AND_ZEROPAGE = 0x25;       // 3, performs (accumulator AND operand) then stores in accumulator
     const static Byte INSTR_6502_AND_ABSOLUTE = 0x2d;       // 4, performs (accumulator AND operand) then stores in accumulator
     const static Byte INSTR_6502_AND_ABSOLUTE_X = 0x3d;       // 4 (+1 if page boundary crossed), performs (accumulator AND operand) then stores in accumulator
+    const static Byte INSTR_6502_AND_ABSOLUTE_Y = 0x39;       // 4 (+1 if page boundary crossed), performs (accumulator AND operand) then stores in accumulator
     const static Byte INSTR_6502_AND_INDIRECT_X = 0x21;       // 6 performs (accumulator AND operand) then stores in accumulator
 
     /***************************************************************************************************************************/

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -773,6 +773,34 @@ void CPU::run(Memory& memory)
                 }
                 break;
             
+            case INSTR_6502_AND_ABSOLUTE_Y:
+                {
+                    Word lookup_address = get_word(memory);
+                    Word old_page = lookup_address & 0xFF00;
+                    lookup_address += Y;
+                    Word new_page = lookup_address & 0xFF00;
+                    Byte operand = get_byte(memory, lookup_address);
+                    IP++;
+                    IP++;
+                    A = A & operand;
+                    if (A == 0)
+                    {
+                        Z = true;
+                    }
+                    if (A & 0b10000000)
+                    {
+                        N = true;
+                    }
+                    sem.wait();
+                    sem.wait();
+                    sem.wait();
+                    if (old_page != new_page) 
+                    {
+                        sem.wait();
+                    }
+                }
+                break;
+            
             case INSTR_6502_AND_INDIRECT_X:
                 {
                     // read next byte and add X without carry

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -781,7 +781,6 @@ void CPU::run(Memory& memory)
 
                     //get target address from indirect_address data and next on zero page
                     Word target_address = get_word_zpg_wrap(memory, indirect_address);
-                    std::cout << "target address: "  << (Word)target_address << "\n";
 
                     // get data from target address
                     Byte operand = get_byte(memory, target_address);
@@ -854,8 +853,8 @@ Word CPU::get_word(Memory& memory, const Word address)
 
 Word CPU::get_word_zpg_wrap(Memory& memory, const Byte address)
 {
-    Word val1 = (Word)memory[address];
-    Word val2 = (Word)memory[address+1];   // This wraps automatically since address is a Byte
+    Word val1 = (Word)memory[address % 256];
+    Word val2 = (Word)memory[(address+1) % 256];   // This wraps automatically since address is a Byte
     return (val2 << 8) | val1;
 }
 

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -772,6 +772,36 @@ void CPU::run(Memory& memory)
                     }
                 }
                 break;
+            
+            case INSTR_6502_AND_INDIRECT_X:
+                {
+                    // read next byte and add X without carry
+                    Byte indirect_address = get_byte(memory) + X;
+                    IP++;
+
+                    //get target address from indirect_address data and next on zero page
+                    Word target_address = get_word_zpg_wrap(memory, indirect_address);
+
+                    // get data from target address
+                    Byte operand = get_byte(memory, target_address);
+
+                    //complete operation
+                    A = A & operand;
+                    if (A == 0)
+                    {
+                        Z = true;
+                    }
+                    if (A & 0b10000000)
+                    {
+                        N = true;
+                    }
+                    sem.wait();
+                    sem.wait();
+                    sem.wait();
+                    sem.wait();
+                    sem.wait();
+                }
+                break;
 
             default:
                 std::cout << "Unknown instruction: 0x" << std::hex << std::setw(2) << std::setfill('0') << (int)instruction << "\n";

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -781,6 +781,7 @@ void CPU::run(Memory& memory)
 
                     //get target address from indirect_address data and next on zero page
                     Word target_address = get_word_zpg_wrap(memory, indirect_address);
+                    std::cout << "target address: "  << (Word)target_address << "\n";
 
                     // get data from target address
                     Byte operand = get_byte(memory, target_address);

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -141,8 +141,8 @@ void System::load_example_prog(unsigned int which)
             //memory[0x00fe] = 0x04;
             memory[0x00ff] = 0x03;
             memory[0x0100] = 0x04;
-            memory[0x0403] = 0xc0;
-            //memory[0x2103] = 0xcc;
+            //memory[0x0403] = 0xc0;
+            memory[0x2103] = 0x0c;
     }
 }
 

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -22,7 +22,7 @@ inline void System::clock_function(Semaphore* cpu_sem, unsigned int cycles)
 
 void System::load_example_prog(unsigned int which)
 {
-    switch (which % 10)
+    switch (which % 11)
     {
         case 0:
             /*  Loads values into A and stores them elsewhere in memory. */
@@ -133,6 +133,13 @@ void System::load_example_prog(unsigned int which)
             memory.data = {
                 0x3d, 0x00 //AND $0000, X
             };
+        case 10: //test for AND with indirect x
+            memory.data = {
+                0x21, 0x00, //AND ($00, X)
+                0x00, 0xc0
+            };
+            memory[0x00cc] = 0x03;
+            memory[0x00cd] = 0x00;
     }
 }
 

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -135,11 +135,14 @@ void System::load_example_prog(unsigned int which)
             };
         case 10: //test for AND with indirect x
             memory.data = {
-                0x21, 0x00, //AND ($00, X)
-                0x00, 0xc0
+                0x21, 0x33, //AND ($33, X)
+                0x00
             };
-            memory[0x00cc] = 0x03;
-            memory[0x00cd] = 0x00;
+            //memory[0x00fe] = 0x04;
+            memory[0x00ff] = 0x03;
+            memory[0x0100] = 0x04;
+            memory[0x0403] = 0xc0;
+            //memory[0x2103] = 0xcc;
     }
 }
 


### PR DESCRIPTION
Added op AND with absolute y address mode.

I'll skip testing on this since it's a direct copy of the absolute x version.