### PR TITLE
zpg.x and zpg.y addressing modes

### DIFF
--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -171,8 +171,8 @@ class CPU
 
         Byte get_data_relative(Memory& memory);
         Byte get_data_immediate(Memory& memory);
-        Byte get_data_zero_page_x(Memory& memory);
-        Byte get_data_zero_page_y(Memory& memory);
+        Byte get_data_zero_page(Memory& memory);
+        Byte get_data_zero_page(Memory& memory, const Byte index);
         Byte get_data_indexed_indirect(Memory& memory, const Byte index);   //(Indirect,X) uses IP as indirect address
         Byte get_data_indirect_indexed(Memory& memory, const Byte index);   //(Indirect),Y uses IP as indirect address
 

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -171,6 +171,8 @@ class CPU
 
         Byte get_data_relative(Memory& memory);
         Byte get_data_immediate(Memory& memory);
+        Byte get_data_zero_page_x(Memory& memory);
+        Byte get_data_zero_page_y(Memory& memory);
         Byte get_data_indexed_indirect(Memory& memory, const Byte index);   //(Indirect,X) uses IP as indirect address
         Byte get_data_indirect_indexed(Memory& memory, const Byte index);   //(Indirect),Y uses IP as indirect address
 

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -929,23 +929,24 @@ Byte CPU::get_data_immediate(Memory& memory)
     return get_byte(memory);
 }
 
-/** \brief Fetches a byte using zpg.x addressing mode.
+/** \brief Fetches a byte using zpg addressing mode.
  * \param memory A reference to a memory array object.
  * \return A Byte from memory.
  */
-Byte CPU::get_data_zero_page_x(Memory& memory)
+Byte CPU::get_data_zero_page(Memory& memory)
 {
-    Byte data_address = get_byte(memory) + X;
+    Byte data_address = get_byte(memory);
     return get_byte(memory, data_address);
 }
 
-/** \brief Fetches a byte using zpg.y addressing mode.
+/** \brief Fetches a byte using zpg addressing mode with an index, typically X or Y register.
  * \param memory A reference to a memory array object.
+ * \param index An index into a memory region.
  * \return A Byte from memory.
  */
-Byte CPU::get_data_zero_page_y(Memory& memory)
+Byte CPU::get_data_zero_page(Memory& memory, const Byte index)
 {
-    Byte data_address = get_byte(memory) + Y;
+    Byte data_address = get_byte(memory) + index;
     return get_byte(memory, data_address);
 }
 

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -929,6 +929,26 @@ Byte CPU::get_data_immediate(Memory& memory)
     return get_byte(memory);
 }
 
+/** \brief Fetches a byte using zpg.x addressing mode.
+ * \param memory A reference to a memory array object.
+ * \return A Byte from memory.
+ */
+Byte CPU::get_data_zero_page_x(Memory& memory)
+{
+    Byte data_address = get_byte(memory) + X;
+    return get_byte(memory, data_address);
+}
+
+/** \brief Fetches a byte using zpg.y addressing mode.
+ * \param memory A reference to a memory array object.
+ * \return A Byte from memory.
+ */
+Byte CPU::get_data_zero_page_y(Memory& memory)
+{
+    Byte data_address = get_byte(memory) + Y;
+    return get_byte(memory, data_address);
+}
+
 Word CPU::get_word_zpg_wrap(Memory& memory, const Byte address)
 {
     Word val1 = (Word)memory[address % 256];


### PR DESCRIPTION
Again, basically identical but I feel having them separate is semantically valuable.